### PR TITLE
[sonoff] refactor polling logic to fix power data missing on POW devices

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -3,6 +3,7 @@
 	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
@@ -37,6 +38,13 @@
 		<attributes>
 			<attribute name="optional" value="true"/>
 			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/src/main/java/org/openhab/binding/sonoff/internal/handler/SonoffSwitchPOWHandler.java
+++ b/src/main/java/org/openhab/binding/sonoff/internal/handler/SonoffSwitchPOWHandler.java
@@ -25,7 +25,8 @@ import org.openhab.binding.sonoff.internal.dto.commands.SingleSwitch;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
-import org.openhab.core.types.*;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,15 +69,22 @@ public class SonoffSwitchPOWHandler extends SonoffBaseDeviceHandler {
                         TimeUnit.SECONDS);
             }
 
-            // Task to poll the lan if we are in local only mode or internet access is blocked (POW / POWR2)
+            // Task to poll the LAN at localPoll interval.
+            // Sends sledOnline with the current LED value so the device responds with all
+            // its params (power, voltage, current) without changing anything.
+            // Ported from SonoffLAN v3.11.0-rc.1 (https://github.com/AlexxIT/SonoffLAN/issues/1707)
             Runnable localPollData = () -> {
-                queueMessage(new SonoffCommandMessage("switch", this.deviceid, true, new SingleSwitch()));
-            };
-            if ((mode.equals("local") || (this.cloud.equals(false) && mode.equals("mixed")))) {
-                if (local) {
-                    logger.debug("Starting local task for {}", config.deviceid);
-                    localTask = scheduler.scheduleWithFixedDelay(localPollData, 10, localPoll, TimeUnit.SECONDS);
+                SonoffDeviceState state = account.getState(this.deviceid);
+                if (state != null) {
+                    String ledValue = state.getParameters().getNetworkLED().toString().toLowerCase();
+                    SLed sled = new SLed();
+                    sled.setSledOnline(ledValue);
+                    queueMessage(new SonoffCommandMessage("sledOnline", this.deviceid, true, sled));
                 }
+            };
+            if (local && (mode.equals("local") || mode.equals("mixed"))) {
+                logger.debug("Starting local task for {}", config.deviceid);
+                localTask = scheduler.scheduleWithFixedDelay(localPollData, 10, localPoll, TimeUnit.SECONDS);
             }
         }
     }
@@ -93,7 +101,6 @@ public class SonoffSwitchPOWHandler extends SonoffBaseDeviceHandler {
             consumptionTask.cancel(true);
             this.consumptionTask = null;
         }
-        super.cancelTasks();
     }
 
     @Override

--- a/src/main/java/org/openhab/binding/sonoff/internal/handler/SonoffSwitchPOWR2Handler.java
+++ b/src/main/java/org/openhab/binding/sonoff/internal/handler/SonoffSwitchPOWR2Handler.java
@@ -25,7 +25,8 @@ import org.openhab.binding.sonoff.internal.dto.commands.SingleSwitch;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
-import org.openhab.core.types.*;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.RefreshType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,15 +70,22 @@ public class SonoffSwitchPOWR2Handler extends SonoffBaseDeviceHandler {
                         TimeUnit.SECONDS);
             }
 
-            // Task to poll the lan if we are in local only mode or internet access is blocked (POW / POWR2)
+            // Task to poll the LAN at localPoll interval.
+            // Sends sledOnline with the current LED value so the device responds with all
+            // its params (power, voltage, current) without changing anything.
+            // Ported from SonoffLAN v3.11.0-rc.1 (https://github.com/AlexxIT/SonoffLAN/issues/1707)
             Runnable localPollData = () -> {
-                queueMessage(new SonoffCommandMessage("switch", this.deviceid, true, new SingleSwitch()));
-            };
-            if ((mode.equals("local") || (this.cloud.equals(false) && mode.equals("mixed")))) {
-                if (local) {
-                    logger.debug("Starting local task for {}", this.deviceid);
-                    localTask = scheduler.scheduleWithFixedDelay(localPollData, 10, localPoll, TimeUnit.SECONDS);
+                SonoffDeviceState state = account.getState(this.deviceid);
+                if (state != null) {
+                    String ledValue = state.getParameters().getNetworkLED().toString().toLowerCase();
+                    SLed sled = new SLed();
+                    sled.setSledOnline(ledValue);
+                    queueMessage(new SonoffCommandMessage("sledOnline", this.deviceid, true, sled));
                 }
+            };
+            if (local && (mode.equals("local") || mode.equals("mixed"))) {
+                logger.debug("Starting local task for {}", this.deviceid);
+                localTask = scheduler.scheduleWithFixedDelay(localPollData, 10, localPoll, TimeUnit.SECONDS);
             }
         }
     }


### PR DESCRIPTION
I started noticing that my POW devices stopped updating the power usage.
After digging a while I found that this issue was also happening in the HA version of this binding (which was used as reference for building this one).
https://github.com/AlexxIT/SonoffLAN/issues/1707

As they have fixed the issue there in this release: https://github.com/AlexxIT/SonoffLAN/releases/tag/v3.11.0-rc.1, I decided to port the fix to my fork and it is working fine since yesterday.

While digging the web to find more about the issue I got to know about this fork that seems to be active.
So, it was fair to me to share the fix here. Feel free to accept or reject.